### PR TITLE
import natsort in sequencing-base

### DIFF
--- a/images/sequencing-base-notebook/Dockerfile
+++ b/images/sequencing-base-notebook/Dockerfile
@@ -32,6 +32,7 @@ RUN mamba install --yes \
     'biopython' \
     'gseapy' \
     'jupyterlab_execute_time' \
+    'natsort' \
     'plotnine' \
     'pybiomart' \
     'openpyxl' \


### PR DESCRIPTION
Fixes fbnrst/sequencing-docker-stacks#48

adds natsort to sequencing-base